### PR TITLE
Added verification at the end of the generate password function

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -52,6 +52,11 @@ function generatePassword() {
     console.log(userCharSet);
   }
 
+  if (charNumber == false && charLower == false && charUpper == false && charSymbols == false){
+    window.alert("Please select at least one available character criteria.")
+    generatePassword();
+  }
+
   for(let i = 0; i < numberOfChar; i++) {
     const randomIndex = Math.floor(Math.random() * userCharSet.length);
     randomPassword += userCharSet[randomIndex];


### PR DESCRIPTION
If the user has not submitted any valid character criteria for their password, it will restart the "generate password" function and give the user an alert that they must select at least one character criteria